### PR TITLE
Patch: Missing platform support, adjusts naming of flag "groups" enum

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,29 +1,29 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
-    name: "Veximoji",
-    platforms: [.iOS(.v13), .macOS(.v10_10) , .watchOS(.v2) , .tvOS(.v9)],
-    products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
-        .library(
-            name: "Veximoji",
-            targets: ["Veximoji"]),
-    ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
-    targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
-        .target(
-            name: "Veximoji",
-            dependencies: []),
-        .testTarget(
-            name: "VeximojiTests",
-            dependencies: ["Veximoji"]),
-    ]
+  name: "Veximoji",
+  platforms: [.iOS("12.0"), .macOS("10.10") , .watchOS("3.1.1") , .tvOS("10.1")],
+  products: [
+    // Products define the executables and libraries a package produces, and make them visible to other packages.
+    .library(
+      name: "Veximoji",
+      targets: ["Veximoji"]),
+  ],
+  dependencies: [
+    // Dependencies declare other packages that this package depends on.
+    // .package(url: /* package url */, from: "1.0.0"),
+  ],
+  targets: [
+    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+    // Targets can depend on other targets in this package, and on products in packages this package depends on.
+    .target(
+      name: "Veximoji",
+      dependencies: []),
+    .testTarget(
+      name: "VeximojiTests",
+      dependencies: ["Veximoji"]),
+  ]
 )

--- a/Sources/Veximoji/Veximoji.swift
+++ b/Sources/Veximoji/Veximoji.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-/// Used to represent an emoji flag group. In the context of `Veximoji`, this class used internally to represent each case of the [Veximoji.FlagGroups](x-source-tag://FlagGroups) enum when calling [Veximoji.getFlag](x-source-tag://getFlag).
+/// Used to represent an emoji flag category. In the context of `Veximoji`, this class used internally to represent each case of the [Veximoji.FlagCategories](x-source-tag://FlagCategories) enum when calling [Veximoji.getFlag](x-source-tag://getFlag).
 /// - Tag: FlagCategory
 fileprivate class FlagCategory {
-  let type: Veximoji.FlagGroups
+  let type: Veximoji.FlagCategories
   let validator: ((_: String) -> Bool)?
   let scalars: [String: [UInt32]]?
   
-  init(type: Veximoji.FlagGroups, validator: ((_: String) -> Bool)?, scalars: [String: [UInt32]]?) {
+  init(type: Veximoji.FlagCategories, validator: ((_: String) -> Bool)?, scalars: [String: [UInt32]]?) {
     self.type = type
     self.validator = validator ?? nil
     self.scalars = scalars ?? nil
@@ -18,9 +18,9 @@ public struct Veximoji {
   
   // MARK: - Enums
   
-  /// An enum representing each emoji flag group.
-  /// - Tag: FlagGroups
-  public enum FlagGroups: String, CaseIterable {
+  /// An enum representing each emoji flag category.
+  /// - Tag: FlagCategories
+  public enum FlagCategories: String, CaseIterable {
     case country = "country"
     case subdivision = "subdivision"
     case international = "international"


### PR DESCRIPTION
- Adds support for watchOS and tvOS
- Adds support for Swift 5.0, 5.1, 5.2, 5.3
- `FlagGroups`, which was previously only used internally (but exposed publicly), has been renamed to `FlagCategories` for consistency. I'm making a one-time exception and not considering the latter a breaking API change or worthy of a minor version increment. In future versions, a change of this nature will likely be deemed as much.