### PR TITLE
Release 2.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
   name: "Veximoji",
-  platforms: [.iOS("12.0"), .macOS("10.10") , .watchOS("3.1.1") , .tvOS("10.1")],
+  platforms: [.iOS(.v12), .macOS(.v10_14) , .watchOS(.v3) , .tvOS(.v10)],
   products: [
     // Products define the executables and libraries a package produces, and make them visible to other packages.
     .library(

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Package installation follows traditional conventions.
 
 #### Manual Installation
 
-Add **`package(url: "https://github.com/roz0n/Veximoji.git", from: "1.0.0")`**  to your application's **`Package.swift`** file.
+Add **`package(url: "https://github.com/roz0n/Veximoji.git", from: "2.0.0")`**  to your application's **`Package.swift`** file.
 
 #### Via Xcode
 
@@ -60,7 +60,7 @@ The **`Veximoji`** API is very concise and well-documented. It supports four dif
 | `country` | flags for countries with an ISO 3611-1 alpha-2 code |`JP`|
 | `subdivision` | flags for subdivisions with an ISO 3611-2 code | `GB-ENG` |
 | `international` | flags for exceptionally reserved ISO 3166-1 alpha-2 codes | `EU` or `UN` |
-| `unique` | flags not related to individual countries or subdivisions | `.pirate` |
+| `unique` | flags not related to individual countries or subdivisions | `.pirate` or `"pirate"`|
 
 Each emoji flag category has a method to obtain its flags.
 
@@ -153,6 +153,8 @@ if let flag = Veximoji.unique(term: .pride)  {
   print("\(flag)") // "🏳️‍🌈"
 }
 ```
+
+
 
 ### Code Validation Methods
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ---
 
 <p align="center" width="100%">
-  Swiftly convert ISO country codes (incl. subdivisions and exceptional reservations) and unique terms to all 269 iOS-supported emoji flags without hassle.
+  Swiftly convert ISO country codes (incl. subdivisions and exceptional reservations) and other unique terms to emoji flags without hassle.
 </p>
 
 ---
@@ -21,9 +21,9 @@
 > **vex·il·lol·o·gy** (/ˌveksəˈläləjē/)
 > *noun*: the study of flags.
 
-From a developer's perspective, emojis are great. They're a vast collection of natively supported and recognizable icons with a wide variety of use cases. They enhance the visual appearance of labels and cells and do not require third-party dependencies.
+From a developer's perspective, emojis are great. They're natively supported and instantly recognizable icons with a variety of use cases.
 
-Working with emojis in Swift is not as *swifty* as it could be, though. **`Veximoji`** aims to remedy that.
+Working with emojis in Swift is not as *swifty* as it could be, though.
 
 ## Demo
 
@@ -31,7 +31,7 @@ Checkout the [**`Veximoji-Example`**](https://github.com/roz0n/Veximoji-Example)
 
 ## Installation
 
-Package installation follows traditional conventions.
+Package installation follows traditional Swift conventions.
 
 ### Swift Package Manager
 
@@ -53,6 +53,12 @@ CocoaPods support is not yet available, but it's on the [**roadmap**](#roadmap).
 
 ## API
 
+### tl:dr;
+
+```swift
+let usa = "us".flag() // "🇺🇸"
+```
+
 The **`Veximoji`** API is very concise and well-documented. It supports four different emoji flag categories:
 
 | Category | Definition | Example |
@@ -62,26 +68,44 @@ The **`Veximoji`** API is very concise and well-documented. It supports four dif
 | `international` | flags for exceptionally reserved ISO 3166-1 alpha-2 codes | `EU` or `UN` |
 | `unique` | flags not related to individual countries or subdivisions | `.pirate` or `"pirate"`|
 
-Each emoji flag category has a method to obtain its flags.
+--
+### `flag(term:) -> String?`
 
-### Flag Category Methods
+Converts any string to its emoji flag counterpart if the string exists within a `FlagCategory`.
 
-#### `country(code:) -> String?`
+- This is the most succinct way to convert a string to its emoji flag form.
+- This method is also included as an extension to `String` for brevity.
+
+#### Usage
+
+```swift
+if let flag = "UN".flag()  {
+	print("\(flag)") // "🇺🇳"
+}
+```
+
+```swift
+if let flag = Veximoji.flag("UN") {
+	print("\(flag)") // "🇺🇳"
+}
+```
+--
+### `country(code:) -> String?`
 
 - Used to render a country's emoji flag by its ISO 3611-1 alpha-2 code
 - Returns a string containing the corresponding flag emoji if the given country code is valid, otherwise returns **`nil`**
 - There is no need to manually check the validity of the given code as this method makes a call to **`validateISO3166_1(code:)`** already
 - For more information on ISO 3611 country codes visit [this Wikipedia article.](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes)
 
-##### Usage
+#### Usage
 
 ```swift
 if let flag = Veximoji.country(code: "DO")  {
   print("\(flag)") // "🇩🇴"
 }
 ```
-
-#### `subdivision(code:) -> String?`
+--
+### `subdivision(code:) -> String?`
 
 - Used to render a given subdivision’s emoji flag by its ISO 3611-2 code
 	- For clarity: England, Scotland, and Wales are considered *subdivisions* of Great Britain 
@@ -89,7 +113,7 @@ if let flag = Veximoji.country(code: "DO")  {
 - There is no need to manually check the validity of the given code as this method makes a call to **`validateISO3166_2(code:)`** already
 - For more information on ISO 3611-2 codes visit [this Wikipedia article.](https://en.wikipedia.org/wiki/ISO_3166-2)
 
-##### Supported Codes
+#### Supported Codes
 
 | Code  | Flag |
 |:--|:--|
@@ -97,43 +121,43 @@ if let flag = Veximoji.country(code: "DO")  {
 | `GB-SCT`  | 🏴󠁧󠁢󠁳󠁣󠁴󠁿 |
 | `GB-WLS`  | 🏴󠁧󠁢󠁷󠁬󠁳󠁿 |
 
-##### Usage
+#### Usage
 
 ```swift
 if let flag = Veximoji.subdivision(code: "GB-SCT")  {
   print("\(flag)") // "🏴󠁧󠁢󠁳󠁣󠁴󠁿"
 }
 ```
-
-#### `international(code:) -> String?`
+--
+### `international(code:) -> String?`
 
 - Used to render the flag of an exceptionally reserved ISO 3166-1 alpha-2 code
 - Returns a string containing the corresponding flag emoji if the given exceptionally reserved code is valid, otherwise returns **`nil`**
 - There is no need to manually check the validity of the given code as this method makes a call to **`validateExceptionalReservation(code:)`** already
 - For more information on exceptionally reserved codes visit [this Wikipedia article.](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Exceptional_reservations)
 
-##### Supported Codes
+#### Supported Codes
 
 | Code  | Flag |
 |:--|:--|
 | `EU`  | 🇪🇺 |
 | `UN`  | 🇺🇳 |
 
-##### Usage
+#### Usage
 
 ```swift
 if let flag = Veximoji.subdivision(code: "UN")  {
   print("\(flag)") // "🇺🇳"
 }
 ```
-
-#### `unique(term:) -> String?`
+--
+### `unique(term:) -> String?`
 
 In the context of **`Veximoji`**, *unique term* refers to an emoji flag that does not correspond to a country or region, but rather to a unique reference, movement, or ideology. For example, **`.pride`** refers to the "rainbow" or "pride" flag.
 
 **`Veximoji`** contains the correct Unicode scalars needed to accurately render each emoji flag. Unlike the other flag category methods, it does not expect a string as input but instead references the publicly exposed **`UniqueTerms`** enum (which also supports raw values).
 
-##### Supported Cases
+#### Supported Cases
 
 | Case  | Raw value | Flag |
 |:--|:--|:--|
@@ -146,7 +170,7 @@ In the context of **`Veximoji`**, *unique term* refers to an emoji flag that doe
 | `.triangular`  | “triangular” | 🚩|
 | `.racing`  | “racing” | 🏁|
 
-##### Usage
+#### Usage
 
 ```swift
 if let flag = Veximoji.unique(term: .pride)  {
@@ -154,74 +178,55 @@ if let flag = Veximoji.unique(term: .pride)  {
 }
 ```
 
-#### `flag(term:) -> String?`
-
-- Converts a given string to an emoji flag if the string exists within a `FlagCategory` category. 
-- This method is the most succint way to convert a string to its emoji flag form.
-
-##### Usage
-
-```swift
-if let flag = "UN".flag()  {
-	print("\(flag)") // "🇺🇳"
-}
-```
-
 ### Code Validation Methods
 
 In the event you would like to validate any of the above codes or terms manually for whatever reason, **`Veximoji`** exposes its validation methods for your convenience.
 
-#### `validateISO3166_1(code:) -> Bool`
+--
+### `validateISO3166_1(code:) -> Bool`
 
 - Returns a boolean indicating whether a given string is a supported ISO 3611 alpha-2 country code by checking whether or not it is contained within the **`CFLocaleCopyISOCountryCodes`** collection
 - For more information on supported country codes visit the [**CFLocaleCopyISOCountryCodes**](https://developer.apple.com/documentation/corefoundation/1543372-cflocalecopyisocountrycodes) page in the Apple Developer Documentation
 
-##### Usage
+#### Usage
 
 ```swift
-let dominicanRepublicCode = "do" // supports uppercase, lowercase, and mixed-case strings
+let code = "do" // supports uppercase, lowercase, and mixed-case strings
 
-if Veximoji.validateISO3166_1(code: dominicanRepublicCode)  {
-  print("That code is valid")
-} else {
-  print("That code is invalid")
+if Veximoji.validateISO3166_1(code: code)  {
+  print("Code is valid")
 }
 ```
-
-#### `validateISO3166_2(code:) -> Bool`
+--
+### `validateISO3166_2(code:) -> Bool`
 
 - Returns a boolean indicating whether a given string is a valid ISO 3611-2 subdivision code
 - Currently, **`Veximoji`** only supports Great Britain’s subdivision codes as they are the only subdivisions with iOS-supported emoji flags
 
-##### Usage
+#### Usage
 
 ```swift
-let scotlandCode = "gb-sct" // supports uppercase, lowercase, and mixed-case strings
+let code = "gb-sct" // supports uppercase, lowercase, and mixed-case strings
 
-if Veximoji.validateISO3166_2(code: scotlandCode)  {
-  print("That code is valid")
-} else {
-  print("That code is invalid")
+if Veximoji.validateISO3166_2(code: code)  {
+  print("Code is valid")
 }
 ```
-
-#### `validateExceptionalReservation(code:) -> Bool`
+--
+### `validateExceptionalReservation(code:) -> Bool`
 
 - Returns a boolean indicating whether a given string is a valid ISO 3166-1 exceptionally reserved code.
 - Currently, **`Veximoji`** only supports `EU` and `UN` exceptionally reserved codes as they are the only codes with iOS-supported emoji flags
 
-##### Usage
+#### Usage
 
 ```swift
-let euCode = "eu" // supports uppercase, lowercase, and mixed-case strings
+let code = "eu" // supports uppercase, lowercase, and mixed-case strings
 
-if Veximoji.validateExceptionalReservation(code: euCode)  {
-  print("That code is valid")
-} else {
-  print("That code is invalid")
+if Veximoji.validateExceptionalReservation(code: code)  {
+  print("Code is valid")
 }
 ```
-
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,18 @@ if let flag = Veximoji.unique(term: .pride)  {
 }
 ```
 
+#### `flag(term:) -> String?`
 
+- Converts a given string to an emoji flag if the string exists within a `FlagCategory` category. 
+- This method is the most succint way to convert a string to its emoji flag form.
+
+##### Usage
+
+```swift
+if let flag = "UN".flag()  {
+	print("\(flag)") // "🇺🇳"
+}
+```
 
 ### Code Validation Methods
 
@@ -211,12 +222,6 @@ if Veximoji.validateExceptionalReservation(code: euCode)  {
 }
 ```
 
-## Roadmap
-
-- ~~Add support for exceptional reservations~~
-- ~~Add support for subdivisions~~
-- CocoaPods support
-- Continually support new emoji flags as they are added to the Unicode standard and supported by Apple development platforms
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,10 @@
 ---
 
 <p align="center" width="100%">
-  Swiftly convert ISO country codes (incl. subdivisions and exceptional reservations) and cultural terms to all 269 iOS-supported emoji flags without hassle.  
+  Swiftly convert ISO country codes (incl. subdivisions and exceptional reservations) and unique terms to all 269 iOS-supported emoji flags without hassle.
 </p>
 
-<br />
-
-<div align="center">
-  <img src="./Diagram.png"> 
-</div>
+---
 
 <br />
 
@@ -64,7 +60,7 @@ The **`Veximoji`** API is very concise and well-documented. It supports four dif
 | `country` | flags for countries with an ISO 3611-1 alpha-2 code |`JP`|
 | `subdivision` | flags for subdivisions with an ISO 3611-2 code | `GB-ENG` |
 | `international` | flags for exceptionally reserved ISO 3166-1 alpha-2 codes | `EU` or `UN` |
-| `cultural` | flags not related to individual countries or subdivisions | `.pirate` |
+| `unique` | flags not related to individual countries or subdivisions | `.pirate` |
 
 Each emoji flag category has a method to obtain its flags.
 
@@ -131,11 +127,11 @@ if let flag = Veximoji.subdivision(code: "UN")  {
 }
 ```
 
-#### `cultural(term:) -> String?`
+#### `unique(term:) -> String?`
 
-In the context of **`Veximoji`**, *cultural term* refers to an emoji flag that does not correspond to a country or region, but rather to a cultural reference, movement, or ideology. For example, **`.pride`** refers to the "rainbow" or "pride" flag.
+In the context of **`Veximoji`**, *unique term* refers to an emoji flag that does not correspond to a country or region, but rather to a unique reference, movement, or ideology. For example, **`.pride`** refers to the "rainbow" or "pride" flag.
 
-**`Veximoji`** contains the correct Unicode scalars needed to accurately render each emoji flag. Unlike the other flag category methods, it does not expect a string as input but instead references the publicly exposed **`CulturalTerms`** enum (which also supports raw values).
+**`Veximoji`** contains the correct Unicode scalars needed to accurately render each emoji flag. Unlike the other flag category methods, it does not expect a string as input but instead references the publicly exposed **`UniqueTerms`** enum (which also supports raw values).
 
 ##### Supported Cases
 
@@ -153,7 +149,7 @@ In the context of **`Veximoji`**, *cultural term* refers to an emoji flag that d
 ##### Usage
 
 ```swift
-if let flag = Veximoji.cultural(term: .pride)  {
+if let flag = Veximoji.unique(term: .pride)  {
   print("\(flag)") // "🏳️‍🌈"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Once the package finishes downloading, should now see it listed in the Project N
 
 ### CocoaPods
 
-CocoaPods support is not yet available, but it's on the [**roadmap**](#roadmap).
+CocoaPods support is not yet available.
 
 ## API
 
@@ -57,6 +57,9 @@ CocoaPods support is not yet available, but it's on the [**roadmap**](#roadmap).
 
 ```swift
 let usa = "us".flag() // "🇺🇸"
+let england = "gb-eng".flag() // "🏴󠁧󠁢󠁥󠁮󠁧󠁿"
+let un = "un".flag() // "🇺🇳"
+let chequered = "chequered".flag() // "🏁"
 ```
 
 The **`Veximoji`** API is very concise and well-documented. It supports four different emoji flag categories:
@@ -73,8 +76,9 @@ The **`Veximoji`** API is very concise and well-documented. It supports four dif
 
 Converts any string to its emoji flag counterpart if the string exists within a `FlagCategory`.
 
+- This method is also provided as an extension to `String` for brevity.
 - This is the most succinct way to convert a string to its emoji flag form.
-- This method is also included as an extension to `String` for brevity.
+- Returns either a string representing the emoji flag or `nil`.
 
 #### Usage
 

--- a/Sources/Veximoji/Veximoji.swift
+++ b/Sources/Veximoji/Veximoji.swift
@@ -404,4 +404,12 @@ extension String {
     return Veximoji.international(code: self)
   }
   
+  public func flag() -> String? {
+    return (
+      self.getCountryFlag() == nil
+      ? (self.getSubdivisonFlag() == nil ? self.getInternationalFlag() : self.getSubdivisonFlag())
+      : self.getCountryFlag()
+    )
+  }
+  
 }

--- a/Sources/Veximoji/Veximoji.swift
+++ b/Sources/Veximoji/Veximoji.swift
@@ -359,7 +359,7 @@ public struct Veximoji {
   /**
    Returns an optional string containing the emoji flag of a given cultural term associated with [Veximoji.CulturalTerms](x-source-tag://CulturalTerms).
    
-   In this context, cultural term refers to an emoji flag that does not correspond to a country or region, but rather to a cultural reference, movement, or ideology. This method receives a cultural term and sequentially appends the corresponding scalars to a string and returns it.
+   In this context, cultural term refers to an emoji flag that does not correspond to a country or region, but rather to a cultural reference, movement, or ideology.
    
    - parameter term: A valid case of [Veximoji.CulturalTerms](x-source-tag://CulturalTerms) (e.g. `.pride` for the rainbow or "pride" flag or `.pirate` for the pirate flag otherwise known as "Jolly Roger")
    - returns: `String?` Either a string representing the emoji flag of the cultural term or `nil`.
@@ -383,7 +383,7 @@ public struct Veximoji {
   }
   
   /**
-   Returns an optional string containing the emoji flag of a given string if it exists.
+   Converts a given string to an emoji flag if the string exists within a [Veximoji.FlagCategory](x-source-tag://FlagCategories) category.
    
    - parameter term: Any valid ISO 3166 alpha-2, ISO 3166-1 alpha-2, ISO 3166-2 code, or [Veximoji.CulturalTerms](x-source-tag://CulturalTerms) raw value.
    - returns: `String?` Either a string representing the emoji flag or `nil`.
@@ -409,7 +409,7 @@ extension String {
    
    # Example #
    ```
-   if let flag = "DO".flag()  {
+   if let flag = "DO".countryFlag()  {
     print("\(flag)")
    }
    ```
@@ -425,7 +425,7 @@ extension String {
    
    # Example #
    ```
-   if let flag = "GB-WLS".flag()  {
+   if let flag = "GB-WLS".subdivisionFlag()  {
     print("\(flag)")
    }
    ```
@@ -441,7 +441,7 @@ extension String {
    
    # Example #
    ```
-   if let flag = "EU".flag()  {
+   if let flag = "EU".internationalFlag()  {
     print("\(flag)")
    }
    ```
@@ -457,7 +457,7 @@ extension String {
    
    # Example #
    ```
-   if let code = "pirate".flag()  {
+   if let code = "pirate".culturalFlag()  {
     print("\(code)")
    }
    ```
@@ -471,7 +471,7 @@ extension String {
   }
   
   /**
-   Converts a text string to a corresponding emoji flag if the string exists within a [Veximoji.FlagCategory](x-source-tag://FlagCategories) category.
+   Converts the string to an emoji flag if the string exists within a [Veximoji.FlagCategory](x-source-tag://FlagCategories) category.
    
    - returns: `String?` Either a string representing the emoji flag or `nil`.
    

--- a/Sources/Veximoji/Veximoji.swift
+++ b/Sources/Veximoji/Veximoji.swift
@@ -228,9 +228,9 @@ public struct Veximoji {
    let dominicanRepublicCode = "do" // supports uppercase, lowercase, and mixed-case strings
    
    if Veximoji.validateISO3166_1(code: dominicanRepublicCode)  {
-    print("That country code is valid")
+   print("That country code is valid")
    } else {
-    print("That country code is invalid")
+   print("That country code is invalid")
    }
    ```
    */
@@ -252,9 +252,9 @@ public struct Veximoji {
    let englandCode = "gb-eng" // supports uppercase, lowercase, and mixed-case strings
    
    if Veximoji.validateISO3166_2(code: englandCode)  {
-    print("That subdivision code is valid")
+   print("That subdivision code is valid")
    } else {
-    print("That subdivision code is invalid")
+   print("That subdivision code is invalid")
    }
    ```
    */
@@ -276,9 +276,9 @@ public struct Veximoji {
    let euCode = "eu" // supports uppercase, lowercase, and mixed-case strings
    
    if Veximoji.validateExceptionalReservation(code: euCode)  {
-    print("That reserved code is valid")
+   print("That reserved code is valid")
    } else {
-    print("That reserved code is invalid")
+   print("That reserved code is invalid")
    }
    ```
    */
@@ -300,7 +300,7 @@ public struct Veximoji {
    # Example #
    ```
    if let emojiFlag = Veximoji.country(code: "DO")  {
-    print("The Dominican Flag: \(emojiFlag)")
+   print("The Dominican Flag: \(emojiFlag)")
    }
    ```
    */
@@ -324,7 +324,7 @@ public struct Veximoji {
    # Example #
    ```
    if let walesFlag = Veximoji.subdivision(code: "GB-WLS")  {
-    print("Baner Cymru: \(walesFlag)")
+   print("Baner Cymru: \(walesFlag)")
    }
    ```
    */
@@ -348,7 +348,7 @@ public struct Veximoji {
    # Example #
    ```
    if let euFlag = Veximoji.international(code: "EU")  {
-    print("The European Union Flag: \(euFlag)")
+   print("The European Union Flag: \(euFlag)")
    }
    ```
    */
@@ -373,7 +373,7 @@ public struct Veximoji {
    # Example #
    ```
    if let pirateEmojiFlag = Veximoji.cultural(named: .pirate)  {
-    print("Jolly Roger": \(pirateEmojiFlag)")
+   print("Jolly Roger": \(pirateEmojiFlag)")
    }
    ```
    */
@@ -386,6 +386,22 @@ public struct Veximoji {
     } else {
       return nil
     }
+  }
+  
+}
+
+extension String {
+  
+  public func getCountryFlag() -> String? {
+    return Veximoji.country(code: self)
+  }
+  
+  public func getSubdivisonFlag() -> String? {
+    return Veximoji.subdivision(code: self)
+  }
+  
+  public func getInternationalFlag() -> String? {
+    return Veximoji.international(code: self)
   }
   
 }

--- a/Sources/Veximoji/Veximoji.swift
+++ b/Sources/Veximoji/Veximoji.swift
@@ -133,7 +133,7 @@ public struct Veximoji {
   /**
    Computes and returns all supported exceptionally reserved [ISO 3166-1](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes) codes.
    
-   For more information on exceptionally reserved codes see [this Wikipedia article](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Exceptional_reservations).
+   For more information on exceptional reservation codes see [this Wikipedia article](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Exceptional_reservations).
    */
   /// - Tag: internationalCodes
   public static var internationalCodes: [String] {
@@ -216,21 +216,21 @@ public struct Veximoji {
   /**
    Returns a boolean indicating whether a given string is a valid country code.
    
-   For more information on ISO 3166-1 country codes see [this Wikipedia article.](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes)
+   For more information on ISO 3166-1 country codes refer to this [Wikipedia page.](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes)
    
-   For more information on supported country codes see the [CFLocaleCopyISOCountryCodes](https://developer.apple.com/documentation/corefoundation/1543372-cflocalecopyisocountrycodes) page in the Apple Developer Documentation.
+   For more information on supported country codes refer to the [CFLocaleCopyISOCountryCodes](https://developer.apple.com/documentation/corefoundation/1543372-cflocalecopyisocountrycodes) page of the Apple Developer Documentation.
    
    - parameter code: A string representing an ISO 3166-1 alpha-2 country code (e.g. "US" for United States of America or "DO" for Dominican Republic)
    - returns: `Bool` Whether or not the given subdivision code is a member of Core Foundation's [CFLocaleCopyISOCountryCodes](https://developer.apple.com/documentation/corefoundation/1543372-cflocalecopyisocountrycodes) collection.
    
    # Example #
    ```
-   let dominicanRepublicCode = "do" // supports uppercase, lowercase, and mixed-case strings
+   let code = "do"
    
-   if Veximoji.validateISO3166_1(code: dominicanRepublicCode)  {
-   print("That country code is valid")
+   if Veximoji.validateISO3166_1(code: code)  {
+    print("Valid code")
    } else {
-   print("That country code is invalid")
+    print("Invalid code")
    }
    ```
    */
@@ -242,19 +242,19 @@ public struct Veximoji {
   /**
    Returns a boolean indicating whether a given string is a valid subdivision code.
    
-   For more information on ISO 3166-2 subdivision codes see [this Wikipedia article.](https://en.wikipedia.org/wiki/ISO_3166-2)
+   For more information on ISO 3166-2 subdivision codes refer to this [Wikipedia article.](https://en.wikipedia.org/wiki/ISO_3166-2)
    
    - parameter code: A string representing an ISO 3166-2 subdivision code, e.g. "GB-ENG" for England or "GB-WLS" for Wales.
    - returns: `Bool` Whether or not the given subdivision code is a valid case of the [Veximoji.ISO3166_2](x-source-tag://ISO3166_2) enum.
    
    # Example #
    ```
-   let englandCode = "gb-eng" // supports uppercase, lowercase, and mixed-case strings
+   let code = "gb-eng"
    
-   if Veximoji.validateISO3166_2(code: englandCode)  {
-   print("That subdivision code is valid")
+   if Veximoji.validateISO3166_2(code: code)  {
+    print("Valid code")
    } else {
-   print("That subdivision code is invalid")
+    print("Invalid code")
    }
    ```
    */
@@ -264,21 +264,21 @@ public struct Veximoji {
   }
   
   /**
-   Returns a boolean indicating whether a given string is a valid ISO 3166-1 exceptionally reserved code.
+   Returns a boolean indicating whether a given string is a valid ISO 3166-1 exceptional reservation code.
    
-   For more information on ISO 3166-1 exceptional reservations see [this Wikipedia article.](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Exceptional_reservations)
+   For more information on ISO 3166-1 exceptional reservations refer to this [Wikipedia article.](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Exceptional_reservations)
    
-   - parameter code: A string representing an ISO 3166-1 exceptionally reserved code, e.g. "EU" for the European Union or "UN" for the United Nations.
-   - returns: `Bool` Whether or not the given exceptionally reserved code is a valid case of the [Veximoji.ExceptionalReservations](x-source-tag://ExceptionalReservations) enum.
+   - parameter code: A string representing an ISO 3166-1 exceptional reservation code, e.g. "EU" for the European Union or "UN" for the United Nations.
+   - returns: `Bool` Whether or not the given exceptional reservation code is a valid case of the [Veximoji.ExceptionalReservations](x-source-tag://ExceptionalReservations) enum.
    
    # Example #
    ```
-   let euCode = "eu" // supports uppercase, lowercase, and mixed-case strings
+   let code = "eu"
    
-   if Veximoji.validateExceptionalReservation(code: euCode)  {
-   print("That reserved code is valid")
+   if Veximoji.validateExceptionalReservation(code: code)  {
+    print("Valid code")
    } else {
-   print("That reserved code is invalid")
+    print("Invalid code")
    }
    ```
    */
@@ -290,7 +290,7 @@ public struct Veximoji {
   // MARK: - Flag Emoji Methods
   
   /**
-   Returns the corresponding emoji flag of a valid and legal ISO 3166 alpha-2 country code.
+   Returns an optional string containing the emoji flag of a valid and legal ISO 3166 alpha-2 country code.
    
    The given country code is deemed valid if it is a member of [Core Foundation's](https://developer.apple.com/documentation/corefoundation) [CFLocaleCopyISOCountryCodes](https://developer.apple.com/documentation/corefoundation/1543372-cflocalecopyisocountrycodes) collection. This condition is only met if [Veximoji.validateISO3166_1](x-source-tag://validateISO3166_1) returns `true` for the given country code.
    
@@ -299,8 +299,8 @@ public struct Veximoji {
    
    # Example #
    ```
-   if let emojiFlag = Veximoji.country(code: "DO")  {
-   print("The Dominican Flag: \(emojiFlag)")
+   if let code = Veximoji.country(code: "DO")  {
+    print("\(code)")
    }
    ```
    */
@@ -314,7 +314,7 @@ public struct Veximoji {
   }
   
   /**
-   Returns the corresponding emoji flag of a valid and legal ISO 3166-2 subdivision code.
+   Returns an optional string containing the emoji flag of a valid and legal ISO 3166-2 subdivision code.
    
    The given subdivision code is deemed valid if it is a member of the [Veximoji.ISO3166_2](x-source-tag://ISO3166_2) enum. This condition is only met if [Veximoji.validateISO3166_2](x-source-tag://validateISO3166_2) returns `true` for the given subdivision code.
    
@@ -323,8 +323,8 @@ public struct Veximoji {
    
    # Example #
    ```
-   if let walesFlag = Veximoji.subdivision(code: "GB-WLS")  {
-   print("Baner Cymru: \(walesFlag)")
+   if let code = Veximoji.subdivision(code: "GB-WLS")  {
+    print("\(code)")
    }
    ```
    */
@@ -338,17 +338,17 @@ public struct Veximoji {
   }
   
   /**
-   Returns the corresponding emoji flag of an exceptionally reserved ISO 3166-1 alpha-2 code.
+   Returns an optional string containing the emoji flag of an exceptionally reserved ISO 3166-1 alpha-2 code.
    
-   The provided exceptionally reserved code is deemed valid if it is a member of the [Veximoji.ExceptionalReservations](x-source-tag://ExceptionalReservations) enum. This condition is only met if [Veximoji.validateExceptionalReservation](x-source-tag://validateExceptionalReservation) returns `true` for the given exceptionally reserved code.
+   The provided exceptional reservation code is deemed valid if it is a member of the [Veximoji.ExceptionalReservations](x-source-tag://ExceptionalReservations) enum. This condition is only met if [Veximoji.validateExceptionalReservation](x-source-tag://validateExceptionalReservation) returns `true` for the given exceptional reservation code.
    
-   - parameter code: A string representing an ISO 3166-1 exceptionally reserved code, e.g. "EU" for the European Union or "UN" for the United Nations.
-   - returns: `String?` Either a string representing the emoji flag of the given exceptionally reserved code, code or `nil` if an invalid or illegal code is provided.
+   - parameter code: A string representing an ISO 3166-1 exceptional reservation code, e.g. "EU" for the European Union or "UN" for the United Nations.
+   - returns: `String?` Either a string representing the emoji flag of the given exceptional reservation code, or `nil` if an invalid or illegal code is provided.
    
    # Example #
    ```
-   if let euFlag = Veximoji.international(code: "EU")  {
-   print("The European Union Flag: \(euFlag)")
+   if let code = Veximoji.international(code: "EU")  {
+    print("\(code)")
    }
    ```
    */
@@ -363,7 +363,7 @@ public struct Veximoji {
   }
   
   /**
-   Returns the corresponding emoji flag of a given cultural term associated with [Veximoji.CulturalTerms](x-source-tag://CulturalTerms).
+   Returns an optional string containing the emoji flag of a given cultural term associated with [Veximoji.CulturalTerms](x-source-tag://CulturalTerms).
    
    In this context, cultural term refers to an emoji flag that does not correspond to a country or region, but rather to a cultural reference, movement, or ideology. This method receives a cultural term and sequentially appends the corresponding scalars to a string and returns it.
    
@@ -372,8 +372,8 @@ public struct Veximoji {
    
    # Example #
    ```
-   if let pirateEmojiFlag = Veximoji.cultural(named: .pirate)  {
-   print("Jolly Roger": \(pirateEmojiFlag)")
+   if let code = Veximoji.cultural(named: .pirate)  {
+    print("\(code)")
    }
    ```
    */
@@ -391,24 +391,68 @@ public struct Veximoji {
 }
 
 extension String {
-  
-  public func getCountryFlag() -> String? {
+  /**
+   Returns an optional string containing the emoji flag of a valid and legal ISO 3166 alpha-2 country code.
+   
+   The given country code is deemed valid if it is a member of [Core Foundation's](https://developer.apple.com/documentation/corefoundation) [CFLocaleCopyISOCountryCodes](https://developer.apple.com/documentation/corefoundation/1543372-cflocalecopyisocountrycodes) collection. This condition is only met if [Veximoji.validateISO3166_1](x-source-tag://validateISO3166_1) returns `true` for the given country code.
+   
+   - parameter code: A string representing a country code, e.g. "US" for United States of America or "DO" for Dominican Republic.
+   - returns: `String?` Either a string representing the emoji flag of the given ISO 3166 country code or `nil` if an invalid or illegal country code is provided.
+   
+   # Example #
+   ```
+   if let flag = "DO".flag()  {
+    print("\(flag)")
+   }
+   ```
+   */
+  public func countryFlag() -> String? {
     return Veximoji.country(code: self)
   }
   
-  public func getSubdivisonFlag() -> String? {
+  /**
+   Returns an optional string containing the emoji flag of a valid and legal ISO 3166-2 subdivision code.
+   
+   The given subdivision code is deemed valid if it is a member of the [Veximoji.ISO3166_2](x-source-tag://ISO3166_2) enum. This condition is only met if [Veximoji.validateISO3166_2](x-source-tag://validateISO3166_2) returns `true` for the given subdivision code.
+   
+   - parameter code: A string representing an ISO 3166-2 subdivision code, e.g. "GB-ENG" for England or "GB-WLS" for Wales.
+   - returns: `String?` Either a string representing the emoji flag of the given subdivision code or `nil` if an invalid or illegal code is provided.
+   
+   # Example #
+   ```
+   if let flag = "GB-WLS".flag()  {
+    print("\(flag)")
+   }
+   ```
+   */
+  public func subdivisionFlag() -> String? {
     return Veximoji.subdivision(code: self)
   }
   
-  public func getInternationalFlag() -> String? {
+  /**
+   Returns an optional string containing the emoji flag of an exceptionally reserved ISO 3166-1 alpha-2 code.
+   
+   The provided exceptional reservation code is deemed valid if it is a member of the [Veximoji.ExceptionalReservations](x-source-tag://ExceptionalReservations) enum. This condition is only met if [Veximoji.validateExceptionalReservation](x-source-tag://validateExceptionalReservation) returns `true` for the given exceptional reservation code.
+   
+   - parameter code: A string representing an ISO 3166-1 exceptional reservation code, e.g. "EU" for the European Union or "UN" for the United Nations.
+   - returns: `String?` Either a string representing the emoji flag of the given exceptional reservation code, or `nil` if an invalid or illegal code is provided.
+   
+   # Example #
+   ```
+   if let flag = "EU".flag()  {
+    print("\(flag)")
+   }
+   ```
+   */
+  public func internationalFlag() -> String? {
     return Veximoji.international(code: self)
   }
   
   public func flag() -> String? {
     return (
-      self.getCountryFlag() == nil
-      ? (self.getSubdivisonFlag() == nil ? self.getInternationalFlag() : self.getSubdivisonFlag())
-      : self.getCountryFlag()
+      self.countryFlag() == nil
+      ? (self.subdivisionFlag() == nil ? self.internationalFlag() : self.subdivisionFlag())
+      : self.countryFlag()
     )
   }
   

--- a/Sources/Veximoji/Veximoji.swift
+++ b/Sources/Veximoji/Veximoji.swift
@@ -34,14 +34,14 @@ public struct Veximoji {
    */
   /// - Tag: CulturalTerms
   public enum CulturalTerms: String, CaseIterable {
-    case pride
-    case trans
-    case pirate
-    case white
-    case black
-    case crossed
-    case triangular
-    case racing
+    case pride = "pride"
+    case trans = "trans"
+    case pirate = "pirate"
+    case white = "white"
+    case red = "red"
+    case black = "black"
+    case crossed = "crossed"
+    case chequered = "chequered"
   }
   
   /**
@@ -78,10 +78,10 @@ public struct Veximoji {
     .trans: [UInt32(127987), UInt32(65039), UInt32(8205), UInt32(9895), UInt32(65039)],
     .pirate: [UInt32(127988), UInt32(8205), UInt32(9760), UInt32(65039)],
     .white: [UInt32(127987), UInt32(65039)],
+    .red: [UInt32(128681)],
     .black: [UInt32(127988)],
     .crossed: [UInt32(127884)],
-    .triangular: [UInt32(128681)],
-    .racing: [UInt32(127937)],
+    .chequered: [UInt32(127937)]
   ]
   
   /**
@@ -165,7 +165,7 @@ public struct Veximoji {
   ///   - query: A unique indentifier for a specific flag (e.g., a ISO 3166 alpha-2 country or reserved code, an ISO 3166-2 subdivision code, or a case of the [Veximoji.CulturalTerms](x-source-tag://CulturalTerms) enum).
   /// - Returns: `Bool` Either a string containing the corresponding flag emoji, or `nil`.
   /// - Tag: getFlag
-  private static func getFlag<T: FlagCategory>(category: T, query: String) -> String? {
+  fileprivate static func getFlag<T: FlagCategory>(category: T, query: String) -> String? {
     var emojiString = ""
     
     if let validator = category.validator {
@@ -220,7 +220,7 @@ public struct Veximoji {
    
    For more information on supported country codes refer to the [CFLocaleCopyISOCountryCodes](https://developer.apple.com/documentation/corefoundation/1543372-cflocalecopyisocountrycodes) page of the Apple Developer Documentation.
    
-   - parameter code: A string representing an ISO 3166-1 alpha-2 country code (e.g. "US" for United States of America or "DO" for Dominican Republic)
+   - parameter code: A string representing an ISO 3166-1 alpha-2 country code (e.g. `"US"` for United States of America or `"DO"` for Dominican Republic)
    - returns: `Bool` Whether or not the given subdivision code is a member of Core Foundation's [CFLocaleCopyISOCountryCodes](https://developer.apple.com/documentation/corefoundation/1543372-cflocalecopyisocountrycodes) collection.
    
    # Example #
@@ -228,9 +228,7 @@ public struct Veximoji {
    let code = "do"
    
    if Veximoji.validateISO3166_1(code: code)  {
-    print("Valid code")
-   } else {
-    print("Invalid code")
+    print("Code is valid")
    }
    ```
    */
@@ -244,7 +242,7 @@ public struct Veximoji {
    
    For more information on ISO 3166-2 subdivision codes refer to this [Wikipedia article.](https://en.wikipedia.org/wiki/ISO_3166-2)
    
-   - parameter code: A string representing an ISO 3166-2 subdivision code, e.g. "GB-ENG" for England or "GB-WLS" for Wales.
+   - parameter code: A string representing an ISO 3166-2 subdivision code, e.g. `"GB-ENG"` for England or `"GB-WLS"` for Wales.
    - returns: `Bool` Whether or not the given subdivision code is a valid case of the [Veximoji.ISO3166_2](x-source-tag://ISO3166_2) enum.
    
    # Example #
@@ -252,9 +250,7 @@ public struct Veximoji {
    let code = "gb-eng"
    
    if Veximoji.validateISO3166_2(code: code)  {
-    print("Valid code")
-   } else {
-    print("Invalid code")
+    print("Code is valid")
    }
    ```
    */
@@ -268,7 +264,7 @@ public struct Veximoji {
    
    For more information on ISO 3166-1 exceptional reservations refer to this [Wikipedia article.](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Exceptional_reservations)
    
-   - parameter code: A string representing an ISO 3166-1 exceptional reservation code, e.g. "EU" for the European Union or "UN" for the United Nations.
+   - parameter code: A string representing an ISO 3166-1 exceptional reservation code, e.g. `"EU"` for the European Union or `"UN"` for the United Nations.
    - returns: `Bool` Whether or not the given exceptional reservation code is a valid case of the [Veximoji.ExceptionalReservations](x-source-tag://ExceptionalReservations) enum.
    
    # Example #
@@ -276,9 +272,7 @@ public struct Veximoji {
    let code = "eu"
    
    if Veximoji.validateExceptionalReservation(code: code)  {
-    print("Valid code")
-   } else {
-    print("Invalid code")
+    print("Code is valid")
    }
    ```
    */
@@ -294,7 +288,7 @@ public struct Veximoji {
    
    The given country code is deemed valid if it is a member of [Core Foundation's](https://developer.apple.com/documentation/corefoundation) [CFLocaleCopyISOCountryCodes](https://developer.apple.com/documentation/corefoundation/1543372-cflocalecopyisocountrycodes) collection. This condition is only met if [Veximoji.validateISO3166_1](x-source-tag://validateISO3166_1) returns `true` for the given country code.
    
-   - parameter code: A string representing a country code, e.g. "US" for United States of America or "DO" for Dominican Republic.
+   - parameter code: A string representing a country code, e.g. `"US"` for United States of America or `"DO"` for Dominican Republic.
    - returns: `String?` Either a string representing the emoji flag of the given ISO 3166 country code or `nil` if an invalid or illegal country code is provided.
    
    # Example #
@@ -318,7 +312,7 @@ public struct Veximoji {
    
    The given subdivision code is deemed valid if it is a member of the [Veximoji.ISO3166_2](x-source-tag://ISO3166_2) enum. This condition is only met if [Veximoji.validateISO3166_2](x-source-tag://validateISO3166_2) returns `true` for the given subdivision code.
    
-   - parameter code: A string representing an ISO 3166-2 subdivision code, e.g. "GB-ENG" for England or "GB-WLS" for Wales.
+   - parameter code: A string representing an ISO 3166-2 subdivision code, e.g. `"GB-ENG"` for England or `"GB-WLS"` for Wales.
    - returns: `String?` Either a string representing the emoji flag of the given subdivision code or `nil` if an invalid or illegal code is provided.
    
    # Example #
@@ -342,7 +336,7 @@ public struct Veximoji {
    
    The provided exceptional reservation code is deemed valid if it is a member of the [Veximoji.ExceptionalReservations](x-source-tag://ExceptionalReservations) enum. This condition is only met if [Veximoji.validateExceptionalReservation](x-source-tag://validateExceptionalReservation) returns `true` for the given exceptional reservation code.
    
-   - parameter code: A string representing an ISO 3166-1 exceptional reservation code, e.g. "EU" for the European Union or "UN" for the United Nations.
+   - parameter code: A string representing an ISO 3166-1 exceptional reservation code, e.g. `"EU"` for the European Union or `"UN"` for the United Nations.
    - returns: `String?` Either a string representing the emoji flag of the given exceptional reservation code, or `nil` if an invalid or illegal code is provided.
    
    # Example #
@@ -367,8 +361,8 @@ public struct Veximoji {
    
    In this context, cultural term refers to an emoji flag that does not correspond to a country or region, but rather to a cultural reference, movement, or ideology. This method receives a cultural term and sequentially appends the corresponding scalars to a string and returns it.
    
-   - parameter term: A valid case of [Veximoji.CulturalTerms](x-source-tag://CulturalTerms) (e.g. `.pride` for the rainbow or "pride" flag or `.pirate` for the pirate flag or "Jolly Roger")
-   - returns: `String?` Either a string representing the emoji flag of the cultural term or `nil` if an invalid or illegal term is provided.
+   - parameter term: A valid case of [Veximoji.CulturalTerms](x-source-tag://CulturalTerms) (e.g. `.pride` for the rainbow or "pride" flag or `.pirate` for the pirate flag otherwise known as "Jolly Roger")
+   - returns: `String?` Either a string representing the emoji flag of the cultural term or `nil`.
    
    # Example #
    ```
@@ -388,15 +382,29 @@ public struct Veximoji {
     }
   }
   
+  /**
+   Returns an optional string containing the emoji flag of a given string if it exists.
+   
+   - parameter term: Any valid ISO 3166 alpha-2, ISO 3166-1 alpha-2, ISO 3166-2 code, or [Veximoji.CulturalTerms](x-source-tag://CulturalTerms) raw value.
+   - returns: `String?` Either a string representing the emoji flag or `nil`.
+   
+   # Example #
+   ```
+   if let code = "UN".flag()  {
+    print("\(code)")
+   }
+   ```
+   */
+  public static func flag(term: String) -> String? {
+    return term.countryFlag() ?? term.subdivisionFlag() ?? term.internationalFlag() ?? term.culturalFlag()
+  }
+  
 }
 
 extension String {
   /**
-   Returns an optional string containing the emoji flag of a valid and legal ISO 3166 alpha-2 country code.
+   Used internally by [String.flag](x-source-tag://flag) to obtain the emoji flag of a valid and legal ISO 3166 alpha-2 country code.
    
-   The given country code is deemed valid if it is a member of [Core Foundation's](https://developer.apple.com/documentation/corefoundation) [CFLocaleCopyISOCountryCodes](https://developer.apple.com/documentation/corefoundation/1543372-cflocalecopyisocountrycodes) collection. This condition is only met if [Veximoji.validateISO3166_1](x-source-tag://validateISO3166_1) returns `true` for the given country code.
-   
-   - parameter code: A string representing a country code, e.g. "US" for United States of America or "DO" for Dominican Republic.
    - returns: `String?` Either a string representing the emoji flag of the given ISO 3166 country code or `nil` if an invalid or illegal country code is provided.
    
    # Example #
@@ -406,16 +414,13 @@ extension String {
    }
    ```
    */
-  private func countryFlag() -> String? {
+  fileprivate func countryFlag() -> String? {
     return Veximoji.country(code: self)
   }
   
   /**
-   Returns an optional string containing the emoji flag of a valid and legal ISO 3166-2 subdivision code.
+   Used internally by [String.flag](x-source-tag://flag) to obtain the emoji flag of a valid and legal ISO 3166-2 subdivision code.
    
-   The given subdivision code is deemed valid if it is a member of the [Veximoji.ISO3166_2](x-source-tag://ISO3166_2) enum. This condition is only met if [Veximoji.validateISO3166_2](x-source-tag://validateISO3166_2) returns `true` for the given subdivision code.
-   
-   - parameter code: A string representing an ISO 3166-2 subdivision code, e.g. "GB-ENG" for England or "GB-WLS" for Wales.
    - returns: `String?` Either a string representing the emoji flag of the given subdivision code or `nil` if an invalid or illegal code is provided.
    
    # Example #
@@ -425,16 +430,13 @@ extension String {
    }
    ```
    */
-  private func subdivisionFlag() -> String? {
+  fileprivate func subdivisionFlag() -> String? {
     return Veximoji.subdivision(code: self)
   }
   
   /**
-   Returns an optional string containing the emoji flag of an exceptionally reserved ISO 3166-1 alpha-2 code.
-   
-   The provided exceptional reservation code is deemed valid if it is a member of the [Veximoji.ExceptionalReservations](x-source-tag://ExceptionalReservations) enum. This condition is only met if [Veximoji.validateExceptionalReservation](x-source-tag://validateExceptionalReservation) returns `true` for the given exceptional reservation code.
-   
-   - parameter code: A string representing an ISO 3166-1 exceptional reservation code, e.g. "EU" for the European Union or "UN" for the United Nations.
+   Used internally by [String.flag](x-source-tag://flag) to obtain the emoji flag of an exceptionally reserved ISO 3166-1 alpha-2 code.
+      
    - returns: `String?` Either a string representing the emoji flag of the given exceptional reservation code, or `nil` if an invalid or illegal code is provided.
    
    # Example #
@@ -444,16 +446,45 @@ extension String {
    }
    ```
    */
-  private func internationalFlag() -> String? {
+  fileprivate func internationalFlag() -> String? {
     return Veximoji.international(code: self)
   }
   
+  /**
+   Returns an optional string containing the emoji flag of a given cultural term associated with [Veximoji.CulturalTerms](x-source-tag://CulturalTerms) raw values.
+      
+   - returns: `String?` Either a string representing the emoji flag of the cultural term raw value or `nil`.
+   
+   # Example #
+   ```
+   if let code = "pirate"  {
+    print("\(code)")
+   }
+   ```
+   */
+  public func culturalFlag() -> String? {
+    if let term = Veximoji.CulturalTerms.allCases.filter ({ $0.rawValue == self }).first {
+      return Veximoji.cultural(term: term)
+    } else {
+      return nil
+    }
+  }
+  
+  /**
+   Converts a text string to a corresponding emoji flag if the string exists within a [Veximoji.FlagCategory](x-source-tag://FlagCategories) category.
+   
+   - returns: `String?` Either a string representing the emoji flag or `nil`.
+   
+   # Example #
+   ```
+   if let code = "UN".flag()  {
+    print("\(code)")
+   }
+   ```
+   */
+  /// - Tag: flag
   public func flag() -> String? {
-    return (
-      self.countryFlag() == nil
-      ? (self.subdivisionFlag() == nil ? self.internationalFlag() : self.subdivisionFlag())
-      : self.countryFlag()
-    )
+    return Veximoji.flag(term: self)
   }
   
 }

--- a/Sources/Veximoji/Veximoji.swift
+++ b/Sources/Veximoji/Veximoji.swift
@@ -406,7 +406,7 @@ extension String {
    }
    ```
    */
-  public func countryFlag() -> String? {
+  private func countryFlag() -> String? {
     return Veximoji.country(code: self)
   }
   
@@ -425,7 +425,7 @@ extension String {
    }
    ```
    */
-  public func subdivisionFlag() -> String? {
+  private func subdivisionFlag() -> String? {
     return Veximoji.subdivision(code: self)
   }
   
@@ -444,7 +444,7 @@ extension String {
    }
    ```
    */
-  public func internationalFlag() -> String? {
+  private func internationalFlag() -> String? {
     return Veximoji.international(code: self)
   }
   

--- a/Sources/Veximoji/Veximoji.swift
+++ b/Sources/Veximoji/Veximoji.swift
@@ -225,9 +225,7 @@ public struct Veximoji {
    
    # Example #
    ```
-   let code = "do"
-   
-   if Veximoji.validateISO3166_1(code: code)  {
+   if Veximoji.validateISO3166_1(code: "do")  {
     print("Code is valid")
    }
    ```
@@ -247,9 +245,7 @@ public struct Veximoji {
    
    # Example #
    ```
-   let code = "gb-eng"
-   
-   if Veximoji.validateISO3166_2(code: code)  {
+   if Veximoji.validateISO3166_2(code: "gb-eng")  {
     print("Code is valid")
    }
    ```
@@ -269,9 +265,7 @@ public struct Veximoji {
    
    # Example #
    ```
-   let code = "eu"
-   
-   if Veximoji.validateExceptionalReservation(code: code)  {
+   if Veximoji.validateExceptionalReservation(code: "eu")  {
     print("Code is valid")
    }
    ```
@@ -293,8 +287,8 @@ public struct Veximoji {
    
    # Example #
    ```
-   if let code = Veximoji.country(code: "DO")  {
-    print("\(code)")
+   if let flag = Veximoji.country(code: "DO")  {
+    print("\(flag)")
    }
    ```
    */
@@ -317,8 +311,8 @@ public struct Veximoji {
    
    # Example #
    ```
-   if let code = Veximoji.subdivision(code: "GB-WLS")  {
-    print("\(code)")
+   if let flag = Veximoji.subdivision(code: "GB-WLS")  {
+    print("\(flag)")
    }
    ```
    */
@@ -341,8 +335,8 @@ public struct Veximoji {
    
    # Example #
    ```
-   if let code = Veximoji.international(code: "EU")  {
-    print("\(code)")
+   if let flag = Veximoji.international(code: "EU")  {
+    print("\(flag)")
    }
    ```
    */
@@ -367,8 +361,8 @@ public struct Veximoji {
    
    # Example #
    ```
-   if let code = Veximoji.unique(named: .pirate)  {
-    print("\(code)")
+   if let flag = Veximoji.unique(named: .pirate)  {
+    print("\(flag)")
    }
    ```
    */
@@ -391,8 +385,8 @@ public struct Veximoji {
    
    # Example #
    ```
-   if let code = "UN".flag()  {
-    print("\(code)")
+   if let flag = "UN".flag()  {
+    print("\(flag)")
    }
    ```
    */
@@ -458,8 +452,8 @@ extension String {
    
    # Example #
    ```
-   if let code = "pirate".uniqueFlag()  {
-    print("\(code)")
+   if let flag = "pirate".uniqueFlag()  {
+    print("\(flag)")
    }
    ```
    */
@@ -478,8 +472,8 @@ extension String {
    
    # Example #
    ```
-   if let code = "UN".flag()  {
-    print("\(code)")
+   if let flag = "UN".flag()  {
+    print("\(flag)")
    }
    ```
    */

--- a/Sources/Veximoji/Veximoji.swift
+++ b/Sources/Veximoji/Veximoji.swift
@@ -284,7 +284,7 @@ public struct Veximoji {
   // MARK: - Flag Emoji Methods
   
   /**
-   Returns an optional string containing the emoji flag of a valid and legal ISO 3166 alpha-2 country code.
+   Returns an optional string containing the emoji flag of a valid ISO 3166 alpha-2 country code.
    
    The given country code is deemed valid if it is a member of [Core Foundation's](https://developer.apple.com/documentation/corefoundation) [CFLocaleCopyISOCountryCodes](https://developer.apple.com/documentation/corefoundation/1543372-cflocalecopyisocountrycodes) collection. This condition is only met if [Veximoji.validateISO3166_1](x-source-tag://validateISO3166_1) returns `true` for the given country code.
    
@@ -308,12 +308,12 @@ public struct Veximoji {
   }
   
   /**
-   Returns an optional string containing the emoji flag of a valid and legal ISO 3166-2 subdivision code.
+   Returns an optional string containing the emoji flag of a valid ISO 3166-2 subdivision code.
    
    The given subdivision code is deemed valid if it is a member of the [Veximoji.ISO3166_2](x-source-tag://ISO3166_2) enum. This condition is only met if [Veximoji.validateISO3166_2](x-source-tag://validateISO3166_2) returns `true` for the given subdivision code.
    
    - parameter code: A string representing an ISO 3166-2 subdivision code, e.g. `"GB-ENG"` for England or `"GB-WLS"` for Wales.
-   - returns: `String?` Either a string representing the emoji flag of the given subdivision code or `nil` if an invalid or illegal code is provided.
+   - returns: `String?` Either a string representing the emoji flag of the given subdivision code or `nil`.
    
    # Example #
    ```
@@ -332,12 +332,12 @@ public struct Veximoji {
   }
   
   /**
-   Returns an optional string containing the emoji flag of an exceptionally reserved ISO 3166-1 alpha-2 code.
+   Returns an optional string containing the emoji flag of an ISO 3166-1 alpha-2 exceptional reservation code.
    
    The provided exceptional reservation code is deemed valid if it is a member of the [Veximoji.ExceptionalReservations](x-source-tag://ExceptionalReservations) enum. This condition is only met if [Veximoji.validateExceptionalReservation](x-source-tag://validateExceptionalReservation) returns `true` for the given exceptional reservation code.
    
    - parameter code: A string representing an ISO 3166-1 exceptional reservation code, e.g. `"EU"` for the European Union or `"UN"` for the United Nations.
-   - returns: `String?` Either a string representing the emoji flag of the given exceptional reservation code, or `nil` if an invalid or illegal code is provided.
+   - returns: `String?` Either a string representing the emoji flag of the given exceptional reservation code or `nil`.
    
    # Example #
    ```
@@ -403,9 +403,9 @@ public struct Veximoji {
 
 extension String {
   /**
-   Used internally by [String.flag](x-source-tag://flag) to obtain the emoji flag of a valid and legal ISO 3166 alpha-2 country code.
+   Used internally by [String.flag](x-source-tag://flag) to obtain the emoji flag of a valid ISO 3166 alpha-2 country code.
    
-   - returns: `String?` Either a string representing the emoji flag of the given ISO 3166 country code or `nil` if an invalid or illegal country code is provided.
+   - returns: `String?` Either a string representing the emoji flag of the given ISO 3166 country code or `nil`.
    
    # Example #
    ```
@@ -419,9 +419,9 @@ extension String {
   }
   
   /**
-   Used internally by [String.flag](x-source-tag://flag) to obtain the emoji flag of a valid and legal ISO 3166-2 subdivision code.
+   Used internally by [String.flag](x-source-tag://flag) to obtain the emoji flag of a valid ISO 3166-2 subdivision code.
    
-   - returns: `String?` Either a string representing the emoji flag of the given subdivision code or `nil` if an invalid or illegal code is provided.
+   - returns: `String?` Either a string representing the emoji flag of the given subdivision code or `nil`.
    
    # Example #
    ```
@@ -435,9 +435,9 @@ extension String {
   }
   
   /**
-   Used internally by [String.flag](x-source-tag://flag) to obtain the emoji flag of an exceptionally reserved ISO 3166-1 alpha-2 code.
+   Used internally by [String.flag](x-source-tag://flag) to obtain the emoji flag of an ISO 3166-1 alpha-2 exceptional reservation code.
       
-   - returns: `String?` Either a string representing the emoji flag of the given exceptional reservation code, or `nil` if an invalid or illegal code is provided.
+   - returns: `String?` Either a string representing the emoji flag of the given exceptional reservation code or `nil`.
    
    # Example #
    ```
@@ -451,18 +451,18 @@ extension String {
   }
   
   /**
-   Returns an optional string containing the emoji flag of a given cultural term associated with [Veximoji.CulturalTerms](x-source-tag://CulturalTerms) raw values.
+   Used internally by [String.flag](x-source-tag://flag) to obtain the emoji flag of a given cultural term associated with [Veximoji.CulturalTerms](x-source-tag://CulturalTerms) raw values.
       
    - returns: `String?` Either a string representing the emoji flag of the cultural term raw value or `nil`.
    
    # Example #
    ```
-   if let code = "pirate"  {
+   if let code = "pirate".flag()  {
     print("\(code)")
    }
    ```
    */
-  public func culturalFlag() -> String? {
+  fileprivate func culturalFlag() -> String? {
     if let term = Veximoji.CulturalTerms.allCases.filter ({ $0.rawValue == self }).first {
       return Veximoji.cultural(term: term)
     } else {

--- a/Sources/Veximoji/Veximoji.swift
+++ b/Sources/Veximoji/Veximoji.swift
@@ -24,16 +24,16 @@ public struct Veximoji {
     case country = "country"
     case subdivision = "subdivision"
     case international = "international"
-    case cultural = "cultural"
+    case unique = "unique"
   }
   
   /**
-   In this context, cultural term refers to an emoji flag that does not correspond to a country or region, but rather to a cultural reference, movement, or ideology.
+   In this context, unique term refers to an emoji flag that does not correspond to a country or region, but rather to a unique reference, movement, or ideology.
    
-   The cultural term enum does not contain raw values. Its usage within `Veximoji` depends on the [Veximoji.culturalTermScalars](x-source-tag://culturalTermScalars) member which maps each enum case to an array of `UInt32` integers.
+   The unique term enum does not contain raw values. Its usage within `Veximoji` depends on the [Veximoji.uniqueTermScalars](x-source-tag://uniqueTermScalars) member which maps each enum case to an array of `UInt32` integers.
    */
-  /// - Tag: CulturalTerms
-  public enum CulturalTerms: String, CaseIterable {
+  /// - Tag: UniqueTerms
+  public enum UniqueTerms: String, CaseIterable {
     case pride = "pride"
     case trans = "trans"
     case pirate = "pirate"
@@ -68,12 +68,12 @@ public struct Veximoji {
   }
   
   /**
-   Contains Unicode scalars for each case of the [Veximoji.CulturalTerms](x-source-tag://CulturalTerms) enum. Each scalar is a `UInt32` value that when sequentially appended to a string's `unicodeScalars` property composes the corresponding emoji flag.
+   Contains Unicode scalars for each case of the [Veximoji.UniqueTerms](x-source-tag://UniqueTerms) enum. Each scalar is a `UInt32` value that when sequentially appended to a string's `unicodeScalars` property composes the corresponding emoji flag.
    
    Public access to this dictionary is restricted. To access the scalars of a particular emoji flag, use the `unicodeScalars` property of its string.
    */
-  /// - Tag: culturalTermScalars
-  fileprivate static let culturalTermScalars: [CulturalTerms: [UInt32]] = [
+  /// - Tag: uniqueTermScalars
+  fileprivate static let uniqueTermScalars: [UniqueTerms: [UInt32]] = [
     .pride: [UInt32(127987), UInt32(65039), UInt32(8205), UInt32(127752)],
     .trans: [UInt32(127987), UInt32(65039), UInt32(8205), UInt32(9895), UInt32(65039)],
     .pirate: [UInt32(127988), UInt32(8205), UInt32(9760), UInt32(65039)],
@@ -143,17 +143,17 @@ public struct Veximoji {
   }
   
   /**
-   Computes and returns raw values of all [Veximoji.CulturalTerms](x-source-tag://CulturalTerms) enum cases.
+   Computes and returns raw values of all [Veximoji.UniqueTerms](x-source-tag://UniqueTerms) enum cases.
    */
-  public static var culturalTerms: [String] {
+  public static var uniqueTerms: [String] {
     get {
-      return CulturalTerms.allCases.map { $0.rawValue }
+      return UniqueTerms.allCases.map { $0.rawValue }
     }
   }
   
-  public static var culturalScalars: [CulturalTerms: [UInt32]] {
+  public static var uniqueScalars: [UniqueTerms: [UInt32]] {
     get {
-      return culturalTermScalars
+      return uniqueTermScalars
     }
   }
   
@@ -162,7 +162,7 @@ public struct Veximoji {
   /// Used internally to create and return an emoji flag based on the `type` property of the given [Veximoji.FlagCategory](x-source-tag://FlagCategory).
   /// - Parameters:
   ///   - category: A class that inherits from [Veximoji.FlagCategory](x-source-tag://FlagCategory)
-  ///   - query: A unique indentifier for a specific flag (e.g., a ISO 3166 alpha-2 country or reserved code, an ISO 3166-2 subdivision code, or a case of the [Veximoji.CulturalTerms](x-source-tag://CulturalTerms) enum).
+  ///   - query: A unique indentifier for a specific flag (e.g., a ISO 3166 alpha-2 country or reserved code, an ISO 3166-2 subdivision code, or a case of the [Veximoji.UniqueTerms](x-source-tag://UniqueTerms) enum).
   /// - Returns: `Bool` Either a string containing the corresponding flag emoji, or `nil`.
   /// - Tag: getFlag
   fileprivate static func getFlag<T: FlagCategory>(category: T, query: String) -> String? {
@@ -196,7 +196,7 @@ public struct Veximoji {
         }
         
         return emojiString
-      case .cultural:
+      case .unique:
         guard let scalars = category.scalars else { return nil }
         guard let values = scalars[query] else { return nil }
         guard !values.isEmpty else { return nil }
@@ -348,8 +348,9 @@ public struct Veximoji {
    */
   public static func international(code internationalCode: String?) -> String? {
     if let internationalCode = internationalCode {
-      let category =  FlagCategory(type: .international, validator: Veximoji.validateExceptionalReservation(code:), scalars: Veximoji.exceptionalReservationScalars)
-      
+      let category =  FlagCategory(type: .international,
+                                   validator: Veximoji.validateExceptionalReservation(code:),
+                                   scalars: Veximoji.exceptionalReservationScalars)
       return getFlag(category: category, query: internationalCode)
     } else {
       return nil
@@ -357,25 +358,25 @@ public struct Veximoji {
   }
   
   /**
-   Returns an optional string containing the emoji flag of a given cultural term associated with [Veximoji.CulturalTerms](x-source-tag://CulturalTerms).
+   Returns an optional string containing the emoji flag of a given unique term associated with [Veximoji.UniqueTerms](x-source-tag://UniqueTerms).
    
-   In this context, cultural term refers to an emoji flag that does not correspond to a country or region, but rather to a cultural reference, movement, or ideology.
+   In this context, unique term refers to an emoji flag that does not correspond to a country or region, but rather to a unique reference, movement, or ideology.
    
-   - parameter term: A valid case of [Veximoji.CulturalTerms](x-source-tag://CulturalTerms) (e.g. `.pride` for the rainbow or "pride" flag or `.pirate` for the pirate flag otherwise known as "Jolly Roger")
-   - returns: `String?` Either a string representing the emoji flag of the cultural term or `nil`.
+   - parameter term: A valid case of [Veximoji.UniqueTerms](x-source-tag://UniqueTerms) (e.g. `.pride` for the rainbow or "pride" flag or `.pirate` for the pirate flag otherwise known as "Jolly Roger")
+   - returns: `String?` Either a string representing the emoji flag of the unique term or `nil`.
    
    # Example #
    ```
-   if let code = Veximoji.cultural(named: .pirate)  {
+   if let code = Veximoji.unique(named: .pirate)  {
     print("\(code)")
    }
    ```
    */
-  public static func cultural(term: CulturalTerms?) -> String? {
+  public static func unique(term: UniqueTerms?) -> String? {
     if let term = term {
-      guard let scalars = culturalTermScalars[term] else { return nil }
+      guard let scalars = uniqueTermScalars[term] else { return nil }
       
-      let category = FlagCategory(type: .cultural, validator: nil, scalars: [term.rawValue: scalars])
+      let category = FlagCategory(type: .unique, validator: nil, scalars: [term.rawValue: scalars])
       return getFlag(category: category, query: term.rawValue)
     } else {
       return nil
@@ -385,7 +386,7 @@ public struct Veximoji {
   /**
    Converts a given string to an emoji flag if the string exists within a [Veximoji.FlagCategory](x-source-tag://FlagCategories) category.
    
-   - parameter term: Any valid ISO 3166 alpha-2, ISO 3166-1 alpha-2, ISO 3166-2 code, or [Veximoji.CulturalTerms](x-source-tag://CulturalTerms) raw value.
+   - parameter term: Any valid ISO 3166 alpha-2, ISO 3166-1 alpha-2, ISO 3166-2 code, or [Veximoji.UniqueTerms](x-source-tag://UniqueTerms) raw value.
    - returns: `String?` Either a string representing the emoji flag or `nil`.
    
    # Example #
@@ -396,7 +397,7 @@ public struct Veximoji {
    ```
    */
   public static func flag(term: String) -> String? {
-    return term.countryFlag() ?? term.subdivisionFlag() ?? term.internationalFlag() ?? term.culturalFlag()
+    return term.countryFlag() ?? term.subdivisionFlag() ?? term.internationalFlag() ?? term.uniqueFlag()
   }
   
 }
@@ -451,20 +452,20 @@ extension String {
   }
   
   /**
-   Used internally by [String.flag](x-source-tag://flag) to obtain the emoji flag of a given cultural term associated with [Veximoji.CulturalTerms](x-source-tag://CulturalTerms) raw values.
+   Used internally by [String.flag](x-source-tag://flag) to obtain the emoji flag of a given unique term associated with [Veximoji.UniqueTerms](x-source-tag://UniqueTerms) raw values.
       
-   - returns: `String?` Either a string representing the emoji flag of the cultural term raw value or `nil`.
+   - returns: `String?` Either a string representing the emoji flag of the unique term raw value or `nil`.
    
    # Example #
    ```
-   if let code = "pirate".culturalFlag()  {
+   if let code = "pirate".uniqueFlag()  {
     print("\(code)")
    }
    ```
    */
-  fileprivate func culturalFlag() -> String? {
-    if let term = Veximoji.CulturalTerms.allCases.filter ({ $0.rawValue == self }).first {
-      return Veximoji.cultural(term: term)
+  fileprivate func uniqueFlag() -> String? {
+    if let term = Veximoji.UniqueTerms.allCases.filter ({ $0.rawValue == self }).first {
+      return Veximoji.unique(term: term)
     } else {
       return nil
     }

--- a/Tests/VeximojiTests/VeximojiTests.swift
+++ b/Tests/VeximojiTests/VeximojiTests.swift
@@ -76,10 +76,7 @@ final class VeximojiTests: XCTestCase {
     for term in Veximoji.CulturalTerms.allCases {
       let scalars = Veximoji.culturalScalars[term]
       
-      // Assert not-nil -- ensures force-unwrapping is safe
       XCTAssertNotNil(scalars, "Each cultural term has an associated entry in the scalars dictionary")
-      
-      // Assert false
       XCTAssertFalse(scalars!.isEmpty, "Each entry in the scalars dictionary is populated")
     }
   }
@@ -93,14 +90,11 @@ final class VeximojiTests: XCTestCase {
     
     let validInputScalars = validInput!.unicodeScalars.first!
     
-    // Assert not-nil -- ensures force-unwrapping is safe
     XCTAssertNotNil(validInputScalars)
     
-    // Assert true
     XCTAssertTrue(type(of: term) == Veximoji.CulturalTerms.self)
     XCTAssertTrue(validInputScalars.properties.isEmoji, "Returns an emoji when a valid country code is given")
     
-    // Assert nil
     XCTAssertNil(nilInput, "Returns nil when nil is given")
   }
   
@@ -113,15 +107,12 @@ final class VeximojiTests: XCTestCase {
     let validInputScalars = validInput!.unicodeScalars.first!
     let lowercasedValidInputScalars = lowercasedValidInput!.unicodeScalars.first!
     
-    // Assert not-nil -- ensures force-unwrapping is safe
     XCTAssertNotNil(validInputScalars)
     XCTAssertNotNil(lowercasedValidInputScalars)
     
-    // Assert true
     XCTAssertTrue(validInputScalars.properties.isEmoji, "Returns an emoji when a valid country code is given")
     XCTAssertTrue(lowercasedValidInputScalars.properties.isEmoji, "Returns an emoji when a valid lowercased country code is given")
     
-    // Assert nil
     XCTAssertNil(invalidInput, "Returns nil when an invalid country code is given")
     XCTAssertNil(nilInput, "Returns nil when nil is given")
   }
@@ -135,15 +126,12 @@ final class VeximojiTests: XCTestCase {
     let validInputScalars = validInput!.unicodeScalars.first!
     let lowercasedValidInputScalars = lowercasedValidInput!.unicodeScalars.first!
     
-    // Assert not-nil -- ensures force-unwrapping is safe
     XCTAssertNotNil(validInputScalars)
     XCTAssertNotNil(lowercasedValidInputScalars)
     
-    // Assert true
     XCTAssertTrue(validInputScalars.properties.isEmoji, "Returns an emoji when a valid country code is given")
     XCTAssertTrue(lowercasedValidInputScalars.properties.isEmoji, "Returns an emoji when a valid lowercased country code is given")
     
-    // Assert nil
     XCTAssertNil(invalidInput, "Returns nil when an invalid code is given")
     XCTAssertNil(nilInput, "Returns nil when nil is given")
   }
@@ -157,57 +145,51 @@ final class VeximojiTests: XCTestCase {
     let validInputScalars = validInput!.unicodeScalars.first!
     let lowercasedValidInputScalars = lowercasedValidInput!.unicodeScalars.first!
     
-    // Assert not-nil -- ensures force-unwrapping is safe
     XCTAssertNotNil(validInputScalars)
     XCTAssertNotNil(lowercasedValidInputScalars)
     
-    // Assert true
     XCTAssertTrue(validInputScalars.properties.isEmoji, "Returns an emoji when a valid international code is given")
     XCTAssertTrue(lowercasedValidInputScalars.properties.isEmoji, "Returns an emoji when a valid lowercased international code is given")
     
-    // Assert nil
     XCTAssertNil(invalidInput, "Returns nil when an invalid code is given")
     XCTAssertNil(nilInput, "Returns nil when an invalid code is given")
+  }
+  
+  // MARK: - String Extension Tests
+  
+  func testsExtensionFlagHelper() {
+    
   }
   
   // MARK: - Validation Tests
   
   func testsISO3166_1Validation() {
-    // Assert not-nil -- ensures force-unwrapping is safe
     XCTAssertNotNil(validCountryCode)
     XCTAssertNotNil(invalidCode)
     
-    // Assert true
     XCTAssertTrue(Veximoji.validateISO3166_1(code: validCountryCode!), "Returns true when a valid country code is given")
     XCTAssertTrue(Veximoji.validateISO3166_1(code: validCountryCode!.lowercased()), "Returns true when a valid lowercased country code is given")
     
-    // Assert false
     XCTAssertFalse(Veximoji.validateISO3166_1(code: invalidCode!), "Returns false when an invalid code is given")
   }
   
   func testsISO3166_2Validation() {
-    // Assert not-nil -- ensures force-unwrapping is safe
     XCTAssertNotNil(validSubdivisonCode)
     XCTAssertNotNil(invalidCode)
     
-    // Assert true
     XCTAssertTrue(Veximoji.validateISO3166_2(code: validSubdivisonCode!), "Returns true when a valid subdivision code is given")
     XCTAssertTrue(Veximoji.validateISO3166_2(code: validSubdivisonCode!.lowercased()), "Returns true when a valid lowercased subdivision code is given")
     
-    // Assert false
     XCTAssertFalse(Veximoji.validateISO3166_2(code: invalidCode!), "Returns false when an invalid code is given")
   }
   
   func testsExceptionalReservationValidation() {
-    // Assert not-nil -- ensures force-unwrapping is safe
     XCTAssertNotNil(validInternationalCode)
     XCTAssertNotNil(invalidCode)
     
-    // Assert true
     XCTAssertTrue(Veximoji.validateExceptionalReservation(code: validInternationalCode!), "Returns true when a valid international code is given")
     XCTAssertTrue(Veximoji.validateExceptionalReservation(code: validInternationalCode!.lowercased()), "Returns true when a valid lowercased international code is given")
     
-    // Assert false
     XCTAssertFalse(Veximoji.validateExceptionalReservation(code: invalidCode!), "Returns false when an invalid code is given")
   }
   

--- a/Tests/VeximojiTests/VeximojiTests.swift
+++ b/Tests/VeximojiTests/VeximojiTests.swift
@@ -158,7 +158,7 @@ final class VeximojiTests: XCTestCase {
   // MARK: - String Extension Tests
   
   func testsExtensionFlagHelper() {
-    
+    let validSubdivisionCode = Veximoji.subdivision(code: <#T##String?#>)
   }
   
   // MARK: - Validation Tests

--- a/Tests/VeximojiTests/VeximojiTests.swift
+++ b/Tests/VeximojiTests/VeximojiTests.swift
@@ -155,12 +155,6 @@ final class VeximojiTests: XCTestCase {
     XCTAssertNil(nilInput, "Returns nil when an invalid code is given")
   }
   
-  // MARK: - String Extension Tests
-  
-  func testsExtensionFlagHelper() {
-    let validSubdivisionCode = Veximoji.subdivision(code: <#T##String?#>)
-  }
-  
   // MARK: - Validation Tests
   
   func testsISO3166_1Validation() {

--- a/Tests/VeximojiTests/VeximojiTests.swift
+++ b/Tests/VeximojiTests/VeximojiTests.swift
@@ -71,13 +71,13 @@ final class VeximojiTests: XCTestCase {
   
   // MARK: - Unicode Scalars Tests
   
-  func testsCulturalTermScalars() {
+  func testsUniqueTermScalars() {
     // Ensures each term has an array of scalars
-    for term in Veximoji.CulturalTerms.allCases {
-      let scalars = Veximoji.culturalScalars[term]
+    for term in Veximoji.UniqueTerms.allCases {
+      let scalars = Veximoji.uniqueScalars[term]
       
       XCTAssertNotNil(scalars,
-                      "Each cultural term has an associated entry in the scalars dictionary")
+                      "Each unique term has an associated entry in the scalars dictionary")
       XCTAssertFalse(scalars!.isEmpty,
                      "Each entry in the scalars dictionary is populated")
     }
@@ -85,15 +85,15 @@ final class VeximojiTests: XCTestCase {
   
   // MARK: - Emoji Flag Tests
   
-  func testsCulturalFlagEmoji() {
-    let term: Veximoji.CulturalTerms = .pirate
-    let validInput = Veximoji.cultural(term: .pirate)
-    let nilInput = Veximoji.cultural(term: nil)
+  func testsUniqueFlagEmoji() {
+    let term: Veximoji.UniqueTerms = .pirate
+    let validInput = Veximoji.unique(term: .pirate)
+    let nilInput = Veximoji.unique(term: nil)
     let validInputScalars = validInput!.unicodeScalars.first!
     
     XCTAssertNotNil(validInputScalars)
     
-    XCTAssertTrue(type(of: term) == Veximoji.CulturalTerms.self)
+    XCTAssertTrue(type(of: term) == Veximoji.UniqueTerms.self)
     XCTAssertTrue(validInputScalars.properties.isEmoji,
                   "Returns an emoji when a valid country code is given")
     

--- a/Tests/VeximojiTests/VeximojiTests.swift
+++ b/Tests/VeximojiTests/VeximojiTests.swift
@@ -76,8 +76,10 @@ final class VeximojiTests: XCTestCase {
     for term in Veximoji.CulturalTerms.allCases {
       let scalars = Veximoji.culturalScalars[term]
       
-      XCTAssertNotNil(scalars, "Each cultural term has an associated entry in the scalars dictionary")
-      XCTAssertFalse(scalars!.isEmpty, "Each entry in the scalars dictionary is populated")
+      XCTAssertNotNil(scalars,
+                      "Each cultural term has an associated entry in the scalars dictionary")
+      XCTAssertFalse(scalars!.isEmpty,
+                     "Each entry in the scalars dictionary is populated")
     }
   }
   
@@ -87,15 +89,16 @@ final class VeximojiTests: XCTestCase {
     let term: Veximoji.CulturalTerms = .pirate
     let validInput = Veximoji.cultural(term: .pirate)
     let nilInput = Veximoji.cultural(term: nil)
-    
     let validInputScalars = validInput!.unicodeScalars.first!
     
     XCTAssertNotNil(validInputScalars)
     
     XCTAssertTrue(type(of: term) == Veximoji.CulturalTerms.self)
-    XCTAssertTrue(validInputScalars.properties.isEmoji, "Returns an emoji when a valid country code is given")
+    XCTAssertTrue(validInputScalars.properties.isEmoji,
+                  "Returns an emoji when a valid country code is given")
     
-    XCTAssertNil(nilInput, "Returns nil when nil is given")
+    XCTAssertNil(nilInput,
+                 "Returns nil when nil is given")
   }
   
   func testsCountryFlagEmoji() {
@@ -110,8 +113,10 @@ final class VeximojiTests: XCTestCase {
     XCTAssertNotNil(validInputScalars)
     XCTAssertNotNil(lowercasedValidInputScalars)
     
-    XCTAssertTrue(validInputScalars.properties.isEmoji, "Returns an emoji when a valid country code is given")
-    XCTAssertTrue(lowercasedValidInputScalars.properties.isEmoji, "Returns an emoji when a valid lowercased country code is given")
+    XCTAssertTrue(validInputScalars.properties.isEmoji,
+                  "Returns an emoji when a valid country code is given")
+    XCTAssertTrue(lowercasedValidInputScalars.properties.isEmoji,
+                  "Returns an emoji when a valid lowercased country code is given")
     
     XCTAssertNil(invalidInput, "Returns nil when an invalid country code is given")
     XCTAssertNil(nilInput, "Returns nil when nil is given")
@@ -129,8 +134,10 @@ final class VeximojiTests: XCTestCase {
     XCTAssertNotNil(validInputScalars)
     XCTAssertNotNil(lowercasedValidInputScalars)
     
-    XCTAssertTrue(validInputScalars.properties.isEmoji, "Returns an emoji when a valid country code is given")
-    XCTAssertTrue(lowercasedValidInputScalars.properties.isEmoji, "Returns an emoji when a valid lowercased country code is given")
+    XCTAssertTrue(validInputScalars.properties.isEmoji,
+                  "Returns an emoji when a valid country code is given")
+    XCTAssertTrue(lowercasedValidInputScalars.properties.isEmoji,
+                  "Returns an emoji when a valid lowercased country code is given")
     
     XCTAssertNil(invalidInput, "Returns nil when an invalid code is given")
     XCTAssertNil(nilInput, "Returns nil when nil is given")
@@ -148,8 +155,10 @@ final class VeximojiTests: XCTestCase {
     XCTAssertNotNil(validInputScalars)
     XCTAssertNotNil(lowercasedValidInputScalars)
     
-    XCTAssertTrue(validInputScalars.properties.isEmoji, "Returns an emoji when a valid international code is given")
-    XCTAssertTrue(lowercasedValidInputScalars.properties.isEmoji, "Returns an emoji when a valid lowercased international code is given")
+    XCTAssertTrue(validInputScalars.properties.isEmoji,
+                  "Returns an emoji when a valid international code is given")
+    XCTAssertTrue(lowercasedValidInputScalars.properties.isEmoji,
+                  "Returns an emoji when a valid lowercased international code is given")
     
     XCTAssertNil(invalidInput, "Returns nil when an invalid code is given")
     XCTAssertNil(nilInput, "Returns nil when an invalid code is given")
@@ -161,30 +170,35 @@ final class VeximojiTests: XCTestCase {
     XCTAssertNotNil(validCountryCode)
     XCTAssertNotNil(invalidCode)
     
-    XCTAssertTrue(Veximoji.validateISO3166_1(code: validCountryCode!), "Returns true when a valid country code is given")
-    XCTAssertTrue(Veximoji.validateISO3166_1(code: validCountryCode!.lowercased()), "Returns true when a valid lowercased country code is given")
-    
-    XCTAssertFalse(Veximoji.validateISO3166_1(code: invalidCode!), "Returns false when an invalid code is given")
+    XCTAssertTrue(Veximoji.validateISO3166_1(code: validCountryCode!),
+                  "Returns true when a valid country code is given")
+    XCTAssertTrue(Veximoji.validateISO3166_1(code: validCountryCode!.lowercased()),
+                  "Returns true when a valid lowercased country code is given")
+    XCTAssertFalse(Veximoji.validateISO3166_1(code: invalidCode!),
+                   "Returns false when an invalid code is given")
   }
   
   func testsISO3166_2Validation() {
     XCTAssertNotNil(validSubdivisonCode)
     XCTAssertNotNil(invalidCode)
     
-    XCTAssertTrue(Veximoji.validateISO3166_2(code: validSubdivisonCode!), "Returns true when a valid subdivision code is given")
-    XCTAssertTrue(Veximoji.validateISO3166_2(code: validSubdivisonCode!.lowercased()), "Returns true when a valid lowercased subdivision code is given")
-    
-    XCTAssertFalse(Veximoji.validateISO3166_2(code: invalidCode!), "Returns false when an invalid code is given")
+    XCTAssertTrue(Veximoji.validateISO3166_2(code: validSubdivisonCode!),
+                  "Returns true when a valid subdivision code is given")
+    XCTAssertTrue(Veximoji.validateISO3166_2(code: validSubdivisonCode!.lowercased()),
+                  "Returns true when a valid lowercased subdivision code is given")
+    XCTAssertFalse(Veximoji.validateISO3166_2(code: invalidCode!),
+                   "Returns false when an invalid code is given")
   }
   
   func testsExceptionalReservationValidation() {
     XCTAssertNotNil(validInternationalCode)
     XCTAssertNotNil(invalidCode)
     
-    XCTAssertTrue(Veximoji.validateExceptionalReservation(code: validInternationalCode!), "Returns true when a valid international code is given")
+    XCTAssertTrue(Veximoji.validateExceptionalReservation(code: validInternationalCode!),
+                  "Returns true when a valid international code is given")
     XCTAssertTrue(Veximoji.validateExceptionalReservation(code: validInternationalCode!.lowercased()), "Returns true when a valid lowercased international code is given")
-    
-    XCTAssertFalse(Veximoji.validateExceptionalReservation(code: invalidCode!), "Returns false when an invalid code is given")
+    XCTAssertFalse(Veximoji.validateExceptionalReservation(code: invalidCode!),
+                   "Returns false when an invalid code is given")
   }
   
 }


### PR DESCRIPTION
Includes various improvements:

- Added `Veximoji.flag()` convenience method
- Adds all `Veximoji` methods as an extension of `String` for brevity
- Renamed cultural flags (`.racing` -> `.chequered`, `.triangular` -> `.red`)
- Added raw values to `Veximoji.CulturalTerms` to allow for string-based conversion of cultural terms to flags, for example `"pride".flag()` -> `"🏳️‍🌈"`
- Renamed `Veximoji.CulturalTerms` to `Veximoji.UniqueTerms`
- Updated documentation
- Updated `README`
